### PR TITLE
Better handling for double names.

### DIFF
--- a/bhamcal/extractor.py
+++ b/bhamcal/extractor.py
@@ -76,7 +76,7 @@ CODE_STRIPPER  = re.compile(
 )
 # Remove duplicates in the case of the name being present twice on some extended modules.
 REMOVE_DOUBLES = re.compile(
-    r".*/(?P<one>^.*)"
+    r"(?P<one>^.*/)"
 )
 
 def clean_subject(subject: str) -> str:

--- a/bhamcal/extractor.py
+++ b/bhamcal/extractor.py
@@ -81,6 +81,9 @@ REMOVE_DOUBLES = re.compile(
 
 def clean_subject(subject: str) -> str:
     subject = re.sub(CODE_STRIPPER, "", subject)
-    subject = re.sub(REMOVE_DOUBLES, "", subject)
+    items = subject.split("/")
+    if len(items) == 2:
+        if items[0].lower().strip() == items[1].lower().strip():
+            subject = re.sub(REMOVE_DOUBLES, "", subject)
 
     return subject.strip()


### PR DESCRIPTION
Only strip duplicates if they are identical.

Allows for cases like `C/C++`